### PR TITLE
Fixed sending non-english messages to groups

### DIFF
--- a/yowsup/layers/protocol_messages/protocolentities/message_text.py
+++ b/yowsup/layers/protocol_messages/protocolentities/message_text.py
@@ -12,7 +12,7 @@ class TextMessageProtocolEntity(MessageProtocolEntity):
     def __init__(self, body, _id = None,  _from = None, to = None, notify = None, 
         timestamp = None, participant = None, offline = None, retry = None):
         super(TextMessageProtocolEntity, self).__init__("text",_id, _from, to, notify, timestamp, participant, offline, retry)
-        self.setBody(body)
+        self.setBody(body.encode('utf-8'))
 
     def __str__(self):
         out  = super(TextMessageProtocolEntity, self).__str__()


### PR DESCRIPTION
This takes care of Unicode text before being converted into bytearray in: yowsup/layers/coder/layer.py line 39: `self.toLower(bytearray(i))`
and also takes care of printing it to the console in: yowsup/structs/protocoltreenode.py line 76: `out += "\nHEX:%s\n" % binascii.hexlify(self.data)`
