### PR TITLE
Update Android env to version `2.16.148`

### DIFF
--- a/yowsup/env/env_android.py
+++ b/yowsup/env/env_android.py
@@ -17,10 +17,10 @@ class AndroidYowsupEnv(YowsupEnv):
         "YHNtYoIvt5R3X6YZylbPftF/8ayWTALBgcqhkjOOAQDBQADLwAwLAIUAKYCp0d6z4QQdyN74JDfQ2WCyi8CFDUM4CaNB+ceVXd" \
         "KtOrNTQcc0e+t"
 
-    _MD5_CLASSES = "ry9Xz6kVioQctwA3G9z62Q=="
+    _MD5_CLASSES = "14w/wF67XBf2vTc+qALwKQ=="
     _KEY = "eQV5aq/Cg63Gsq1sshN9T3gh+UUp0wIw0xgHYT1bnCjEqOJQKCRrWxdAe2yvsDeCJL+Y4G3PRD2HUF7oUgiGo8vGlNJOaux26k+A2F3hj8A="
 
-    _VERSION = "2.12.556"
+    _VERSION = "2.16.148"
     _OS_NAME = "Android"
     _OS_VERSION = "4.3"
     _DEVICE_NAME = "armani"


### PR DESCRIPTION
Updates Android env to version `2.16.148` and code requests work again (no more `old_version` failures).  I'm not sure if there are more changes that should be done other than this so let me know if there are any.

This change fixes https://github.com/jlguardi/yowsup/issues/92 (at least for me).
